### PR TITLE
added support for pop_os

### DIFF
--- a/wpreddit/wallpaper.py
+++ b/wpreddit/wallpaper.py
@@ -31,7 +31,7 @@ def linux_wallpaper():
     try:
         if config.setcmd != '':
             check_call(config.setcmd.split(" "))
-        elif check_de(de, ["gnome", "gnome-xorg", "gnome-wayland", "unity", "ubuntu", "ubuntu-xorg", "budgie-desktop"]):
+        elif check_de(de, ["gnome", "gnome-xorg", "gnome-wayland", "unity", "ubuntu", "ubuntu-xorg", "budgie-desktop","pop"]):
             check_call(["gsettings", "set", "org.gnome.desktop.background", "picture-uri",
                                    "file://%s" % path])
         elif check_de(de, ["cinnamon"]):


### PR DESCRIPTION
In Pop!_OS the desktop session environment variable is set to pop and not gnome so just by adding pop to the DE list it will no longer throw the "DE not found error".